### PR TITLE
feat(service): use generic BaseCond with PKFieldType in service template

### DIFF
--- a/cmd/generate/tpl_generic_id_test.go
+++ b/cmd/generate/tpl_generic_id_test.go
@@ -43,6 +43,7 @@ func TestDaoTplRenderGenericID(t *testing.T) {
 	}
 	params := map[string]any{
 		"PKFieldType":    "uint",
+		"PackageName":    "user",
 		"DaoPackageName": "dao",
 		"ModelLayerName": "model",
 		"StructName":     "User",
@@ -63,6 +64,10 @@ func TestDaoTplRenderGenericID(t *testing.T) {
 				t.Errorf("%s missing %q\n---\n%s", fsPath, want, out)
 			}
 		}
+	}
+	// service 模板的 PageList 构造 Cond 时同样需要携带主键类型参数。
+	if out := renderTpl(t, "generate/module/service.go.tpl", params); !strings.Contains(out, "&gormdao.BaseCond[uint]{") {
+		t.Errorf("generate/module/service.go.tpl missing &gormdao.BaseCond[uint]{:\n%s", out)
 	}
 }
 

--- a/template/generate/module/service.go.tpl
+++ b/template/generate/module/service.go.tpl
@@ -138,7 +138,7 @@ func (svc *{{.StructNameLowerCamel}}Svc) Detail(ctx *gin.Context, req *dto{{.Pac
 // PageList 分页获取{{.Description}}列表
 func (svc *{{.StructNameLowerCamel}}Svc) PageList(ctx *gin.Context, req *dto{{.PackageName}}.{{.StructName}}PageListReq) (*dto{{.PackageName}}.{{.StructName}}PageListResp, error) {
 	cond := &{{.DaoPackageName}}.{{.StructName}}Cond{
-		BaseCond: &gormdao.BaseCond{
+		BaseCond: &gormdao.BaseCond[{{.PKFieldType}}]{
 			Page:     req.Page,
 			PageSize: req.PageSize,
 		},


### PR DESCRIPTION
## 背景

代码生成器的 `service.go.tpl` 中 `PageList` 构造 `BaseCond` 时仍使用非泛型的 `*gormdao.BaseCond`，与 golib v1.32.x 中 `BaseCond[T]` 泛型化的接口不匹配，导致生成的 service 代码在泛型主键（如 `uint`）下编译/构造类型不一致。

## 改动

- `template/generate/module/service.go.tpl`：`PageList` 的 `BaseCond` 使用泛型 `BaseCond[{{.PKFieldType}}]`，与表主键类型对齐。
- `cmd/generate/tpl_generic_id_test.go`：为 `service.go.tpl` 补充渲染断言，校验生成结果包含 `&gormdao.BaseCond[uint]{`，并新增 `PackageName` 测试参数。

## 影响范围

仅涉及代码生成模板及对应单测，无运行时行为改动。
